### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/188/861/421188861.geojson
+++ b/data/421/188/861/421188861.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"MM",
     "wof:created":1459009586,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7d19bc83d21d975e1b9bf756b0195422",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":421188861,
-    "wof:lastmodified":1566610365,
+    "wof:lastmodified":1582380868,
     "wof:name":"Pegu",
     "wof:parent_id":1092044937,
     "wof:placetype":"locality",

--- a/data/421/188/865/421188865.geojson
+++ b/data/421/188/865/421188865.geojson
@@ -272,6 +272,7 @@
     "qs:woe_id":1017865,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "wd:latitude":20.144444,
@@ -293,6 +294,10 @@
     },
     "wof:country":"MM",
     "wof:created":1459009586,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b8d4196ce13cb5ecb69d5f9f46fa2633",
     "wof:hierarchy":[
         {
@@ -304,7 +309,7 @@
         }
     ],
     "wof:id":421188865,
-    "wof:lastmodified":1561843799,
+    "wof:lastmodified":1582380869,
     "wof:name":"Sittwe",
     "wof:parent_id":1092047375,
     "wof:placetype":"locality",

--- a/data/856/321/81/85632181.geojson
+++ b/data/856/321/81/85632181.geojson
@@ -1138,6 +1138,11 @@
     },
     "wof:country":"MM",
     "wof:country_alpha3":"MMR",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"b1fe253073ebe20f8a039778eae15bc7",
     "wof:hierarchy":[
         {
@@ -1152,7 +1157,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608176,
+    "wof:lastmodified":1582380808,
     "wof:name":"Myanmar",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/745/51/85674551.geojson
+++ b/data/856/745/51/85674551.geojson
@@ -170,6 +170,9 @@
         "unlc:id":"MM-12"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fcad8cbfbec0b03bb7bc93c4c85de69f",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608193,
+    "wof:lastmodified":1582380818,
     "wof:name":"Kayah",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/57/85674557.geojson
+++ b/data/856/745/57/85674557.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Kayin State"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8891181cb593d1fb3f2d64af5a71bef",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608191,
+    "wof:lastmodified":1582380816,
     "wof:name":"Kayin",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/59/85674559.geojson
+++ b/data/856/745/59/85674559.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Mandalay Region"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8af8b000bc79b9ee63dcee6b275f637",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608190,
+    "wof:lastmodified":1582380816,
     "wof:name":"Mandalay",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/65/85674565.geojson
+++ b/data/856/745/65/85674565.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Bago Region"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13362a1aceef357c3e8a000a54edd915",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608196,
+    "wof:lastmodified":1582380819,
     "wof:name":"Bago",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/69/85674569.geojson
+++ b/data/856/745/69/85674569.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Yangon Region"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4f59a6396a4e1abd1f7a18d396dae1b",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608192,
+    "wof:lastmodified":1582380817,
     "wof:name":"Yangon",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/75/85674575.geojson
+++ b/data/856/745/75/85674575.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Mon State"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dad3ad506daf13d7f75ceabbeaf0610b",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608195,
+    "wof:lastmodified":1582380818,
     "wof:name":"Mon",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/79/85674579.geojson
+++ b/data/856/745/79/85674579.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Rakhine State"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7c2baeaa54a0f77b117466fd4c6f650",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608199,
+    "wof:lastmodified":1582380821,
     "wof:name":"Rakhine",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/81/85674581.geojson
+++ b/data/856/745/81/85674581.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Chin State"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c85275991ccab0e418aa052e53924aa",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608195,
+    "wof:lastmodified":1582380819,
     "wof:name":"Chin",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/85/85674585.geojson
+++ b/data/856/745/85/85674585.geojson
@@ -328,6 +328,9 @@
         "wk:page":"Ayeyarwady Region"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5043dc4d6c10108aa4232c0acf1267d4",
     "wof:hierarchy":[
         {
@@ -343,7 +346,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608200,
+    "wof:lastmodified":1582380822,
     "wof:name":"Ayeyarwady",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/89/85674589.geojson
+++ b/data/856/745/89/85674589.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Magway Region"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"145620b27a8a85304e013d3bac62fccf",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608194,
+    "wof:lastmodified":1582380818,
     "wof:name":"Magway",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/95/85674595.geojson
+++ b/data/856/745/95/85674595.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Shan State"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80d97b189f05b88f2b914c53d90e46d5",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608188,
+    "wof:lastmodified":1582380814,
     "wof:name":"Shan",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/99/85674599.geojson
+++ b/data/856/745/99/85674599.geojson
@@ -292,6 +292,9 @@
         "wd:id":"Q843954"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f43dbc1580ea8c6391ed655cf70d3168",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608196,
+    "wof:lastmodified":1582380819,
     "wof:name":"Tanintharyi",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/746/05/85674605.geojson
+++ b/data/856/746/05/85674605.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Kachin State"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"726ceafeca7050dd6bd61510c2a2b096",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608172,
+    "wof:lastmodified":1582380805,
     "wof:name":"Kachin",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/746/07/85674607.geojson
+++ b/data/856/746/07/85674607.geojson
@@ -281,6 +281,9 @@
         "wd:id":"Q847289"
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9513e8af51630c86709a90723b774727",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1566608174,
+    "wof:lastmodified":1582380805,
     "wof:name":"Sagaing",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/859/027/13/85902713.geojson
+++ b/data/859/027/13/85902713.geojson
@@ -97,6 +97,9 @@
         "qs_pg:id":894706
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"090be8dc72d08d34bdb02dbbec495906",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566608172,
+    "wof:lastmodified":1582380804,
     "wof:name":"Ahlone",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/15/85902715.geojson
+++ b/data/859/027/15/85902715.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":238637
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"016b2c46d079a64ba423c171d7f467cc",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566608172,
+    "wof:lastmodified":1582380804,
     "wof:name":"Ashebyin",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/17/85902717.geojson
+++ b/data/859/027/17/85902717.geojson
@@ -72,6 +72,9 @@
         "qs:id":478667
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1dc95548bedf7d1a63ed4a3fc3241ab0",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379380,
+    "wof:lastmodified":1582380802,
     "wof:name":"Atet Sidi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/19/85902719.geojson
+++ b/data/859/027/19/85902719.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":240592
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6b041ed7ca49fa2eb56cc4db77d5793",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566608172,
+    "wof:lastmodified":1582380802,
     "wof:name":"Botataung",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/21/85902721.geojson
+++ b/data/859/027/21/85902721.geojson
@@ -80,6 +80,9 @@
         "qs:id":316360
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9efe27819b99423507c65ab14a23a790",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379380,
+    "wof:lastmodified":1582380803,
     "wof:name":"Fort Dufferin",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/25/85902725.geojson
+++ b/data/859/027/25/85902725.geojson
@@ -74,6 +74,9 @@
         "qs:id":478668
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"826d3058c25a8934e7dc11e040175dbb",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379380,
+    "wof:lastmodified":1582380804,
     "wof:name":"Kemmendine",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/27/85902727.geojson
+++ b/data/859/027/27/85902727.geojson
@@ -78,6 +78,9 @@
         "qs:id":1167810
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b27536ed60101515d7e8f1695a1a886",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379380,
+    "wof:lastmodified":1582380802,
     "wof:name":"Pazundaung",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/29/85902729.geojson
+++ b/data/859/027/29/85902729.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1117302
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8fd759412bcfd487dbcbac0979ecec7",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566608171,
+    "wof:lastmodified":1582380802,
     "wof:name":"Shwebya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/31/85902731.geojson
+++ b/data/859/027/31/85902731.geojson
@@ -92,6 +92,9 @@
         "qs_pg:id":1083504
     },
     "wof:country":"MM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00de97a5544aeb09adc8b83a7d9b6bc1",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566608172,
+    "wof:lastmodified":1582380804,
     "wof:name":"Tamwe",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/440/013/890440013.geojson
+++ b/data/890/440/013/890440013.geojson
@@ -262,6 +262,9 @@
     },
     "wof:country":"MM",
     "wof:created":1469052259,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5dbf9b7b632e151fe130f88bd383e47",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         }
     ],
     "wof:id":890440013,
-    "wof:lastmodified":1566610368,
+    "wof:lastmodified":1582380869,
     "wof:name":"Monywa",
     "wof:parent_id":1092046719,
     "wof:placetype":"locality",

--- a/data/890/443/763/890443763.geojson
+++ b/data/890/443/763/890443763.geojson
@@ -346,6 +346,9 @@
     },
     "wof:country":"MM",
     "wof:created":1469052437,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44cb839de93f182f0f226b2e3370cad0",
     "wof:hierarchy":[
         {
@@ -357,7 +360,7 @@
         }
     ],
     "wof:id":890443763,
-    "wof:lastmodified":1566610370,
+    "wof:lastmodified":1582380869,
     "wof:name":"Mandalay",
     "wof:parent_id":1092046205,
     "wof:placetype":"locality",

--- a/data/890/445/571/890445571.geojson
+++ b/data/890/445/571/890445571.geojson
@@ -538,6 +538,9 @@
     },
     "wof:country":"MM",
     "wof:created":1469052515,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"f4abbbc3c1cfb13ae80033faab3b48f2",
     "wof:hierarchy":[
         {
@@ -556,7 +559,7 @@
         }
     ],
     "wof:id":890445571,
-    "wof:lastmodified":1566610371,
+    "wof:lastmodified":1582380869,
     "wof:name":"Nay Pyi Taw",
     "wof:parent_id":1092045099,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.