### PR TITLE
Name updates

### DIFF
--- a/data/114/190/835/5/1141908355.geojson
+++ b/data/114/190/835/5/1141908355.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"97.8678657623,15.2532666208,97.8678657623,15.2532666208",
+    "geom:bbox":"97.867866,15.253267,97.867866,15.253267",
     "geom:latitude":15.253267,
     "geom:longitude":97.867866,
     "iso:country":"MM",
@@ -37,7 +37,7 @@
         "\u092f\u0947"
     ],
     "name:hin_x_variant":[
-        "\u092f\u0947 "
+        "\u092f\u0947"
     ],
     "name:ita_x_preferred":[
         "Ye"
@@ -183,8 +183,8 @@
     "wof:belongsto":[
         102191569,
         85632181,
-        85674575,
-        1092046407
+        1092046407,
+        85674575
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -192,7 +192,7 @@
     },
     "wof:country":"MM",
     "wof:created":1499130884,
-    "wof:geomhash":"c3ac2a65d9bd930dc96542d42e96705e",
+    "wof:geomhash":"f42d7895c45ab32bd0136dd9112d9656",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -203,7 +203,7 @@
         }
     ],
     "wof:id":1141908355,
-    "wof:lastmodified":1566611571,
+    "wof:lastmodified":1587163114,
     "wof:name":"Ye",
     "wof:parent_id":1092046407,
     "wof:placetype":"locality",
@@ -213,10 +213,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    97.86786576232322,
-    15.25326662084575,
-    97.86786576232322,
-    15.25326662084575
+    97.867866,
+    15.253267,
+    97.867866,
+    15.253267
 ],
-  "geometry": {"coordinates":[97.86786576232322,15.25326662084575],"type":"Point"}
+  "geometry": {"coordinates":[97.86786600000001,15.253267],"type":"Point"}
 }

--- a/data/856/321/81/85632181.geojson
+++ b/data/856/321/81/85632181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":58.266674,
-    "geom:area_square_m":670769667999.376099,
+    "geom:area_square_m":670769673664.417236,
     "geom:bbox":"92.171808,9.592889,101.170272,28.547835",
     "geom:latitude":21.113608,
     "geom:longitude":96.50564,
@@ -62,6 +62,9 @@
     "name:arg_x_preferred":[
         "Myanmar"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u064a\u0631\u0645\u0627\u0646\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0645\u064a\u0627\u0646\u0645\u0627\u0631"
     ],
@@ -85,6 +88,9 @@
     ],
     "name:bam_x_preferred":[
         "Myanimari"
+    ],
+    "name:ban_x_preferred":[
+        "Myanmar"
     ],
     "name:bar_x_preferred":[
         "Myanmar"
@@ -192,6 +198,12 @@
     "name:dan_x_variant":[
         "Myanmar"
     ],
+    "name:deu_at_x_preferred":[
+        "Myanmar"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Myanmar"
+    ],
     "name:deu_x_preferred":[
         "Myanmar"
     ],
@@ -221,6 +233,12 @@
     ],
     "name:ell_x_variant":[
         "\u039c\u03c5\u03b1\u03bd\u03bc\u03ac\u03c1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Burma"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Myanmar"
     ],
     "name:eng_x_preferred":[
         "Myanmar"
@@ -305,6 +323,9 @@
     ],
     "name:gan_x_preferred":[
         "\u7dec\u7538"
+    ],
+    "name:gcr_x_preferred":[
+        "Birmani"
     ],
     "name:ger_x_variant":[
         "Union Myanmar"
@@ -403,6 +424,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0544\u0575\u0561\u0576\u0574\u0561"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0544\u056b\u0561\u0576\u0574\u0561"
     ],
     "name:ido_x_preferred":[
         "Myanmar"
@@ -602,6 +626,9 @@
     "name:mon_x_preferred":[
         "\u041c\u044c\u044f\u043d\u043c\u0430\u0440"
     ],
+    "name:mri_x_preferred":[
+        "P\u0113ma"
+    ],
     "name:msa_x_preferred":[
         "Myanmar"
     ],
@@ -719,6 +746,9 @@
     "name:pol_x_variant":[
         "Myanmar"
     ],
+    "name:por_br_x_preferred":[
+        "Myanmar"
+    ],
     "name:por_x_preferred":[
         "Myanmar"
     ],
@@ -766,6 +796,9 @@
         "\u092c\u094d\u0930\u0939\u094d\u092e\u0926\u0947\u0936",
         "\u092e\u094d\u092f\u0928\u094d\u092e\u093e\u0930"
     ],
+    "name:sat_x_preferred":[
+        "\u1c62\u1c64\u1c6d\u1c5f\u1c71\u1c62\u1c5f\u1c68"
+    ],
     "name:scn_x_preferred":[
         "Myanmar"
     ],
@@ -777,6 +810,9 @@
     ],
     "name:sgs_x_preferred":[
         "Mianmars"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u1062\u107c\u103a\u1088"
     ],
     "name:sin_x_preferred":[
         "\u0db6\u0dd4\u0dbb\u0dd4\u0db8\u0dba"
@@ -833,6 +869,12 @@
     "name:srd_x_variant":[
         "Birmania"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u041c\u0458\u0430\u043d\u043c\u0430\u0440"
+    ],
+    "name:srp_el_x_preferred":[
+        "Mjanmar"
+    ],
     "name:srp_x_preferred":[
         "\u041c\u0458\u0430\u043d\u043c\u0430\u0440"
     ],
@@ -859,6 +901,9 @@
     ],
     "name:szl_x_preferred":[
         "Birma"
+    ],
+    "name:szy_x_preferred":[
+        "Burma"
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bbf\u0baf\u0bbe\u0ba9\u0bcd\u0bae\u0bb0\u0bcd"
@@ -1158,7 +1203,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1583797390,
+    "wof:lastmodified":1587428720,
     "wof:name":"Myanmar",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/890/443/751/890443751.geojson
+++ b/data/890/443/751/890443751.geojson
@@ -28,11 +28,17 @@
     "name:ara_x_preferred":[
         "\u064a\u0627\u0646\u063a\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u064a\u0627\u0646\u062c\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
         "Yang\u00f4n"
     ],
     "name:aze_x_preferred":[
         "Yanqon"
+    ],
+    "name:bak_x_preferred":[
+        "\u042f\u043d\u0433\u043e\u043d"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u042f\u043d\u0433\u043e\u043d"
@@ -62,6 +68,9 @@
         "\u042f\u043d\u0433\u043e\u043d"
     ],
     "name:cat_x_preferred":[
+        "Yangon"
+    ],
+    "name:cdo_x_preferred":[
         "Yangon"
     ],
     "name:ces_x_preferred":[
@@ -163,6 +172,9 @@
     "name:hye_x_preferred":[
         "\u0545\u0561\u0576\u0563\u0578\u0576"
     ],
+    "name:hyw_x_preferred":[
+        "\u0535\u0561\u0576\u056f\u0578\u0576"
+    ],
     "name:ido_x_preferred":[
         "Rangoon"
     ],
@@ -210,6 +222,9 @@
     ],
     "name:lat_x_preferred":[
         "Yangon"
+    ],
+    "name:lat_x_variant":[
+        "Rangunum"
     ],
     "name:lav_x_preferred":[
         "Jangona"
@@ -312,6 +327,9 @@
     ],
     "name:sco_x_preferred":[
         "Yangon"
+    ],
+    "name:shn_x_preferred":[
+        "\u1010\u1083\u1088\u1075\u102f\u1004\u103a\u1088\u104a \u101d\u1035\u1004\u103a\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0dba\u0dd0\u0db1\u0dca\u0d9c\u0ddc\u0db1\u0dca"
@@ -498,8 +516,8 @@
     "wof:belongsto":[
         102191569,
         85632181,
-        85674569,
-        1092047923
+        1092047923,
+        85674569
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -522,7 +540,7 @@
         }
     ],
     "wof:id":890443751,
-    "wof:lastmodified":1566610371,
+    "wof:lastmodified":1587428724,
     "wof:name":"Rangoon",
     "wof:parent_id":1092047923,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.