### PR TITLE
mm concordances, placetype local, and more

### DIFF
--- a/data/109/204/493/7/1092044937.geojson
+++ b/data/109/204/493/7/1092044937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.12797,
-    "geom:area_square_m":13285022420.660294,
+    "geom:area_square_m":13285023487.739042,
     "geom:bbox":"95.90674,16.817888,97.222453,18.477977",
     "geom:latitude":17.726957,
     "geom:longitude":96.594552,
@@ -97,9 +97,10 @@
         "hasc:id":"MM.BA.BG",
         "wd:id":"Q4842056"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898316,
-    "wof:geomhash":"a5c0028c35c77ed585344b8a07ba92a0",
+    "wof:geomhash":"9114024581af2fff7747236081187482",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1092044937,
-    "wof:lastmodified":1636504981,
+    "wof:lastmodified":1695886165,
     "wof:name":"Bago",
     "wof:parent_id":85674565,
     "wof:placetype":"county",

--- a/data/109/204/497/3/1092044973.geojson
+++ b/data/109/204/497/3/1092044973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.443857,
-    "geom:area_square_m":5191999148.010966,
+    "geom:area_square_m":5191999375.729624,
     "geom:bbox":"96.943864,18.491094,97.845314,19.34247",
     "geom:latitude":18.914236,
     "geom:longitude":97.428445,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"MM.KH.BW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898318,
-    "wof:geomhash":"9a5bade2ed21acb5a0838d93c392e5e6",
+    "wof:geomhash":"a005b10d48008cb0d7822510648d2677",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092044973,
-    "wof:lastmodified":1627522351,
+    "wof:lastmodified":1695886799,
     "wof:name":"Bawlake",
     "wof:parent_id":85674551,
     "wof:placetype":"county",

--- a/data/109/204/503/1/1092045031.geojson
+++ b/data/109/204/503/1/1092045031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.962113,
-    "geom:area_square_m":10846149630.115837,
+    "geom:area_square_m":10846148819.001999,
     "geom:bbox":"96.549987,23.634138,97.768675,24.901395",
     "geom:latitude":24.258093,
     "geom:longitude":97.162048,
@@ -99,9 +99,10 @@
         "hasc:id":"MM.KC.BM",
         "wd:id":"Q4900952"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898320,
-    "wof:geomhash":"7f9f0a7d5a564775a90285ffc2df9515",
+    "wof:geomhash":"2ce6e216eb34151fa7827f8819b382a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1092045031,
-    "wof:lastmodified":1690939653,
+    "wof:lastmodified":1695886843,
     "wof:name":"Bhamo",
     "wof:parent_id":85674605,
     "wof:placetype":"county",

--- a/data/109/204/506/1/1092045061.geojson
+++ b/data/109/204/506/1/1092045061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.150787,
-    "geom:area_square_m":13801214569.853203,
+    "geom:area_square_m":13801216714.98173,
     "geom:bbox":"97.779556,13.277472,99.21033,15.10223",
     "geom:latitude":14.089461,
     "geom:longitude":98.470103,
@@ -91,9 +91,10 @@
         "hasc:id":"MM.TN.DW",
         "wd:id":"Q5242297"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898321,
-    "wof:geomhash":"cc914f655e9adde95b7480e739cd2374",
+    "wof:geomhash":"8ae941b4f63b3c9819f573be7334aff6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092045061,
-    "wof:lastmodified":1636504980,
+    "wof:lastmodified":1695886163,
     "wof:name":"Dawei",
     "wof:parent_id":85674599,
     "wof:placetype":"county",

--- a/data/109/204/509/9/1092045099.geojson
+++ b/data/109/204/509/9/1092045099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303364,
-    "geom:area_square_m":3532909356.860439,
+    "geom:area_square_m":3532909619.199129,
     "geom:bbox":"95.711838,19.418204,96.673356,19.939303",
     "geom:latitude":19.640138,
     "geom:longitude":96.169091,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"MM.MD.YM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898323,
-    "wof:geomhash":"08861384958c13ad1082f3a63a122de1",
+    "wof:geomhash":"671048ccd7a0dfbe596d254c7938cefb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1092045099,
-    "wof:lastmodified":1627522352,
+    "wof:lastmodified":1695886799,
     "wof:name":"Det Khi Na",
     "wof:parent_id":1108804897,
     "wof:placetype":"county",

--- a/data/109/204/514/9/1092045149.geojson
+++ b/data/109/204/514/9/1092045149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.755006,
-    "geom:area_square_m":8566401673.48539,
+    "geom:area_square_m":8566401655.150648,
     "geom:bbox":"93.324205,22.786867,94.151813,24.106396",
     "geom:latitude":23.421865,
     "geom:longitude":93.714763,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"MM.CH.FL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898324,
-    "wof:geomhash":"8d922b40ba6608de8a12c01699f373ab",
+    "wof:geomhash":"eacb93a82bd1b009fee59552f0b09c87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092045149,
-    "wof:lastmodified":1627522352,
+    "wof:lastmodified":1695886799,
     "wof:name":"Falam",
     "wof:parent_id":85674581,
     "wof:placetype":"county",

--- a/data/109/204/518/9/1092045189.geojson
+++ b/data/109/204/518/9/1092045189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.488078,
-    "geom:area_square_m":5603250279.064137,
+    "geom:area_square_m":5603250710.725607,
     "geom:bbox":"93.979953,20.821524,94.439307,22.763971",
     "geom:latitude":21.803029,
     "geom:longitude":94.182138,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"MM.MG.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898326,
-    "wof:geomhash":"a4a26260479686866cad10079739cd27",
+    "wof:geomhash":"62d4ebd8a023983d6be305ef1fdbd17d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092045189,
-    "wof:lastmodified":1627522352,
+    "wof:lastmodified":1695886799,
     "wof:name":"Gangaw",
     "wof:parent_id":85674589,
     "wof:placetype":"county",

--- a/data/109/204/522/7/1092045227.geojson
+++ b/data/109/204/522/7/1092045227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.678884,
-    "geom:area_square_m":7754772557.424623,
+    "geom:area_square_m":7754773212.61702,
     "geom:bbox":"93.091917,22.007873,94.052108,23.077209",
     "geom:latitude":22.51249,
     "geom:longitude":93.563641,
@@ -95,9 +95,10 @@
         "hasc:id":"MM.CH.FL",
         "wd:id":"Q5640446"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898328,
-    "wof:geomhash":"23a66d02e9560fd553feb7e58f9455c9",
+    "wof:geomhash":"3972af5346c3530f67d77f3c2b5fa680",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1092045227,
-    "wof:lastmodified":1690939664,
+    "wof:lastmodified":1695886166,
     "wof:name":"Hakha",
     "wof:parent_id":85674581,
     "wof:placetype":"county",

--- a/data/109/204/527/7/1092045277.geojson
+++ b/data/109/204/527/7/1092045277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.597046,
-    "geom:area_square_m":7026130400.54504,
+    "geom:area_square_m":7026129394.129354,
     "geom:bbox":"94.780717,17.338409,95.736495,18.510625",
     "geom:latitude":17.875244,
     "geom:longitude":95.19033,
@@ -105,9 +105,10 @@
         "hasc:id":"MM.AY.HD",
         "wd:id":"Q11917372"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898329,
-    "wof:geomhash":"0be286f09f98aaf53626a9ed26607b78",
+    "wof:geomhash":"bd9ad57ccc28f3098a4551c96a321e2c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1092045277,
-    "wof:lastmodified":1690939658,
+    "wof:lastmodified":1695886162,
     "wof:name":"Hinthada",
     "wof:parent_id":85674585,
     "wof:placetype":"county",

--- a/data/109/204/532/7/1092045327.geojson
+++ b/data/109/204/532/7/1092045327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.886808,
-    "geom:area_square_m":32137257843.940948,
+    "geom:area_square_m":32137258095.070881,
     "geom:bbox":"94.536054,24.296945,97.069332,27.376638",
     "geom:latitude":25.790724,
     "geom:longitude":95.551231,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"MM.SA.HK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898330,
-    "wof:geomhash":"c2e866463a3c1f69d1d6d0d38205d4d5",
+    "wof:geomhash":"21fd24f8e35135db8409ec175e2206bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092045327,
-    "wof:lastmodified":1627522352,
+    "wof:lastmodified":1695886799,
     "wof:name":"Hkamti",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/536/7/1092045367.geojson
+++ b/data/109/204/536/7/1092045367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.407744,
-    "geom:area_square_m":4640109386.180164,
+    "geom:area_square_m":4640109492.591736,
     "geom:bbox":"98.435346,22.715327,99.56603,23.488954",
     "geom:latitude":23.026317,
     "geom:longitude":98.968342,
@@ -80,9 +80,10 @@
         "hasc:id":"MM.SH.LS",
         "wd:id":"Q5898982"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898332,
-    "wof:geomhash":"308b8a4f0cae5e86952e20d473d7f982",
+    "wof:geomhash":"53643fcca43d5f04d9517bd4849c0304",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092045367,
-    "wof:lastmodified":1690939660,
+    "wof:lastmodified":1695886799,
     "wof:name":"Hopang",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/541/7/1092045417.geojson
+++ b/data/109/204/541/7/1092045417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.925038,
-    "geom:area_square_m":10891849130.478069,
+    "geom:area_square_m":10891851061.638561,
     "geom:bbox":"96.394527,16.51416,98.322761,19.505371",
     "geom:latitude":17.756581,
     "geom:longitude":97.451018,
@@ -94,9 +94,10 @@
         "hasc:id":"MM.KN.HP",
         "wd:id":"Q5923224"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898333,
-    "wof:geomhash":"0aeddde94b8d869ed340244282d87c3f",
+    "wof:geomhash":"4de0201e9468ea5a32e7fbb1eaecfec4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092045417,
-    "wof:lastmodified":1627522359,
+    "wof:lastmodified":1695886804,
     "wof:name":"Hpa-An",
     "wof:parent_id":85674557,
     "wof:placetype":"county",

--- a/data/109/204/546/7/1092045467.geojson
+++ b/data/109/204/546/7/1092045467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.574392,
-    "geom:area_square_m":6751801725.281112,
+    "geom:area_square_m":6751801041.772289,
     "geom:bbox":"96.932938,17.328946,97.767417,18.812884",
     "geom:latitude":18.076301,
     "geom:longitude":97.368628,
@@ -60,9 +60,10 @@
     "wof:concordances":{
         "hasc:id":"MM.KN.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898335,
-    "wof:geomhash":"767c809e87d7dc91412ba63e952a0007",
+    "wof:geomhash":"d14ec1bfd4d719e5f55e13fb583ea70e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +73,7 @@
         }
     ],
     "wof:id":1092045467,
-    "wof:lastmodified":1627522353,
+    "wof:lastmodified":1695886799,
     "wof:name":"Hpapun",
     "wof:parent_id":85674557,
     "wof:placetype":"county",

--- a/data/109/204/550/3/1092045503.geojson
+++ b/data/109/204/550/3/1092045503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.759978,
-    "geom:area_square_m":8644982409.369211,
+    "geom:area_square_m":8644982159.632187,
     "geom:bbox":"93.948932,22.252364,94.949569,23.655453",
     "geom:latitude":23.080194,
     "geom:longitude":94.409478,
@@ -91,9 +91,10 @@
         "hasc:id":"MM.SA.KM",
         "wd:id":"Q6351853"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898337,
-    "wof:geomhash":"6073bfd0233e6cc92b4eb65e98e2e374",
+    "wof:geomhash":"2b0f9eea283a5763c7988b32314b500b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092045503,
-    "wof:lastmodified":1690939653,
+    "wof:lastmodified":1695886800,
     "wof:name":"Kale",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/554/3/1092045543.geojson
+++ b/data/109/204/554/3/1092045543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.408313,
-    "geom:area_square_m":15892802262.578384,
+    "geom:area_square_m":15892802867.882843,
     "geom:bbox":"95.017996,23.483836,96.663963,24.962426",
     "geom:latitude":24.125067,
     "geom:longitude":95.84501,
@@ -85,9 +85,10 @@
         "hasc:id":"MM.SA.KA",
         "wd:id":"Q6376075"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898338,
-    "wof:geomhash":"94bca95726db9f858dde4e3a995a7f77",
+    "wof:geomhash":"521975cf9b5ec802b5d4e7b84dfac077",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092045543,
-    "wof:lastmodified":1690939660,
+    "wof:lastmodified":1695886800,
     "wof:name":"Katha",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/558/3/1092045583.geojson
+++ b/data/109/204/558/3/1092045583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.810654,
-    "geom:area_square_m":9635200567.853384,
+    "geom:area_square_m":9635200431.585739,
     "geom:bbox":"97.81497,15.220098,98.610764,16.857501",
     "geom:latitude":16.003322,
     "geom:longitude":98.226259,
@@ -91,9 +91,10 @@
         "hasc:id":"MM.KN.KK",
         "wd:id":"Q6380015"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898339,
-    "wof:geomhash":"c114ba8ec3ac92429de0432fe5a40bc3",
+    "wof:geomhash":"10d0e96f6d41bf5deeabead175b90895",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092045583,
-    "wof:lastmodified":1627522353,
+    "wof:lastmodified":1695886800,
     "wof:name":"Kawkareik",
     "wof:parent_id":85674557,
     "wof:placetype":"county",

--- a/data/109/204/562/5/1092045625.geojson
+++ b/data/109/204/562/5/1092045625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.003764,
-    "geom:area_square_m":12169017661.090353,
+    "geom:area_square_m":12169018539.194548,
     "geom:bbox":"97.442108,9.59875,99.325884,12.822889",
     "geom:latitude":11.331427,
     "geom:longitude":98.687404,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"MM.TN.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898341,
-    "wof:geomhash":"4b67e811cb2246b6936ed57703c6275c",
+    "wof:geomhash":"306f53779c2fbe1fda3538909806f1ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1092045625,
-    "wof:lastmodified":1627522353,
+    "wof:lastmodified":1695886800,
     "wof:name":"Kawthoung",
     "wof:parent_id":85674599,
     "wof:placetype":"county",

--- a/data/109/204/568/3/1092045683.geojson
+++ b/data/109/204/568/3/1092045683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.93393,
-    "geom:area_square_m":10737902296.868568,
+    "geom:area_square_m":10737902210.690414,
     "geom:bbox":"98.912966,20.967226,100.233521,22.160172",
     "geom:latitude":21.589477,
     "geom:longitude":99.583235,
@@ -99,9 +99,10 @@
         "hasc:id":"MM.SH.KT",
         "wd:id":"Q6389198"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898343,
-    "wof:geomhash":"8687696ce8f16104bf13d95c21403e0f",
+    "wof:geomhash":"d3c58456f3c57e3118894eaf0586fbfd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1092045683,
-    "wof:lastmodified":1690939653,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kengtung",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/572/9/1092045729.geojson
+++ b/data/109/204/572/9/1092045729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07687,
-    "geom:area_square_m":872114713.296837,
+    "geom:area_square_m":872115226.882155,
     "geom:bbox":"98.422608,23.216467,98.81792,23.691595",
     "geom:latitude":23.434157,
     "geom:longitude":98.607256,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"MM.SH.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898345,
-    "wof:geomhash":"20627088b7f946a16fd98ce43b74b811",
+    "wof:geomhash":"8014913a603ec6987a70b544c5629500",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092045729,
-    "wof:lastmodified":1627522354,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kunlong",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/576/5/1092045765.geojson
+++ b/data/109/204/576/5/1092045765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.270292,
-    "geom:area_square_m":25858475390.987396,
+    "geom:area_square_m":25858476008.978085,
     "geom:bbox":"96.150842,21.937808,98.021809,24.161715",
     "geom:latitude":22.902731,
     "geom:longitude":97.006283,
@@ -93,9 +93,10 @@
         "hasc:id":"MM.SH.KY",
         "wd:id":"Q6450766"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898346,
-    "wof:geomhash":"01f8fc413595fbdc0c6705adbfa7958c",
+    "wof:geomhash":"703adc685afe4791735a35f55d5927b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1092045765,
-    "wof:lastmodified":1690939664,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kyaukme",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/581/9/1092045819.geojson
+++ b/data/109/204/581/9/1092045819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.775916,
-    "geom:area_square_m":9033732965.88603,
+    "geom:area_square_m":9033733464.91671,
     "geom:bbox":"93.469582,18.599556,94.381471,20.57123",
     "geom:latitude":19.678307,
     "geom:longitude":93.926211,
@@ -97,9 +97,10 @@
         "hasc:id":"MM.RA.KP",
         "wd:id":"Q11917391"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898348,
-    "wof:geomhash":"9a6d2f5aae7ad369b6bbbda3019c78c4",
+    "wof:geomhash":"420db004b1420f23a51d15ea207b8c6c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1092045819,
-    "wof:lastmodified":1690939657,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kyaukpyu",
     "wof:parent_id":85674579,
     "wof:placetype":"county",

--- a/data/109/204/586/7/1092045867.geojson
+++ b/data/109/204/586/7/1092045867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.36232,
-    "geom:area_square_m":4165063378.952079,
+    "geom:area_square_m":4165063946.879248,
     "geom:bbox":"95.748624,21.143908,96.893695,22.024229",
     "geom:latitude":21.615993,
     "geom:longitude":96.227,
@@ -108,9 +108,10 @@
         "hasc:id":"MM.ML.KS",
         "wd:id":"Q6450781"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898350,
-    "wof:geomhash":"b3797ca8b5edce9bfd9577017d200483",
+    "wof:geomhash":"433e3f1124a0b0fc4360388e9baa376d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092045867,
-    "wof:lastmodified":1690939656,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kyaukse",
     "wof:parent_id":85674559,
     "wof:placetype":"county",

--- a/data/109/204/590/3/1092045903.geojson
+++ b/data/109/204/590/3/1092045903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.341787,
-    "geom:area_square_m":4059326515.95379,
+    "geom:area_square_m":4059326657.949305,
     "geom:bbox":"94.547058,15.712889,95.531549,16.587844",
     "geom:latitude":16.156622,
     "geom:longitude":94.982946,
@@ -128,9 +128,10 @@
         "hasc:id":"MM.AY.MM",
         "wd:id":"Q6467701"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898351,
-    "wof:geomhash":"4952ca67c2f28c5fd8ad99a6bf29e8e8",
+    "wof:geomhash":"741723aa2c7f4e37476c0c5101862863",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1092045903,
-    "wof:lastmodified":1690939659,
+    "wof:lastmodified":1695886164,
     "wof:name":"Labutta",
     "wof:parent_id":85674585,
     "wof:placetype":"county",

--- a/data/109/204/594/7/1092045947.geojson
+++ b/data/109/204/594/7/1092045947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.170452,
-    "geom:area_square_m":13580317915.227003,
+    "geom:area_square_m":13580318244.828014,
     "geom:bbox":"97.388175,19.575771,98.697867,20.961995",
     "geom:latitude":20.224875,
     "geom:longitude":98.065092,
@@ -60,9 +60,10 @@
     "wof:concordances":{
         "hasc:id":"MM.SH.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898353,
-    "wof:geomhash":"fa3a641c6e3c9e33acf3d5d7aa4e7bc7",
+    "wof:geomhash":"aa71b14e7dbaa9243139ea1302409856",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -72,7 +73,7 @@
         }
     ],
     "wof:id":1092045947,
-    "wof:lastmodified":1627522355,
+    "wof:lastmodified":1695886802,
     "wof:name":"Langkho",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/600/1/1092046001.geojson
+++ b/data/109/204/600/1/1092046001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.130973,
-    "geom:area_square_m":12897916006.705627,
+    "geom:area_square_m":12897915149.963779,
     "geom:bbox":"97.517122,21.838542,98.766623,23.401321",
     "geom:latitude":22.734178,
     "geom:longitude":98.159242,
@@ -103,9 +103,10 @@
         "hasc:id":"MM.SH.LS",
         "wd:id":"Q15241752"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898354,
-    "wof:geomhash":"4c14d7518f68ccde48d18d335dcdc9a8",
+    "wof:geomhash":"cfa8d669f389d9c363a2d623e1eb9673",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1092046001,
-    "wof:lastmodified":1690939663,
+    "wof:lastmodified":1695886802,
     "wof:name":"Lashio",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/603/5/1092046035.geojson
+++ b/data/109/204/603/5/1092046035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162467,
-    "geom:area_square_m":1837609619.423687,
+    "geom:area_square_m":1837609668.219922,
     "geom:bbox":"98.400034,23.462235,98.897954,24.155806",
     "geom:latitude":23.833986,
     "geom:longitude":98.652903,
@@ -91,9 +91,10 @@
         "hasc:id":"MM.SH.LU",
         "wd:id":"Q6498281"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898356,
-    "wof:geomhash":"ea2d36d38c7f313c71bb6e24a7382503",
+    "wof:geomhash":"64dcf8e3b76c847c17f31b8674ae802f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092046035,
-    "wof:lastmodified":1690939655,
+    "wof:lastmodified":1695886802,
     "wof:name":"Laukkaing",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/606/7/1092046067.geojson
+++ b/data/109/204/606/7/1092046067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.565874,
-    "geom:area_square_m":6596344561.412569,
+    "geom:area_square_m":6596344604.276705,
     "geom:bbox":"96.819841,19.02014,97.888151,19.996601",
     "geom:latitude":19.485406,
     "geom:longitude":97.332638,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"MM.KH.LK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898358,
-    "wof:geomhash":"bf17ced5008eee6d3e91376384703189",
+    "wof:geomhash":"9edaae59318d413262afd40e6439077a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1092046067,
-    "wof:lastmodified":1636504982,
+    "wof:lastmodified":1695886167,
     "wof:name":"Loikaw",
     "wof:parent_id":85674551,
     "wof:placetype":"county",

--- a/data/109/204/611/5/1092046115.geojson
+++ b/data/109/204/611/5/1092046115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.716452,
-    "geom:area_square_m":19761323118.138626,
+    "geom:area_square_m":19761322869.058113,
     "geom:bbox":"97.130117,20.438429,98.803675,22.141095",
     "geom:latitude":21.39402,
     "geom:longitude":97.927078,
@@ -97,9 +97,10 @@
         "hasc:id":"MM.SH.LL",
         "wd:id":"Q6668104"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898359,
-    "wof:geomhash":"c472315c8efdefaaeb0c7e773933e999",
+    "wof:geomhash":"70c57b85648bb878ade69aa109a6f9bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1092046115,
-    "wof:lastmodified":1690939655,
+    "wof:lastmodified":1695886802,
     "wof:name":"Loilen",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/615/9/1092046159.geojson
+++ b/data/109/204/615/9/1092046159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.83423,
-    "geom:area_square_m":9676755237.496754,
+    "geom:area_square_m":9676755116.682688,
     "geom:bbox":"94.686277,19.627765,95.833738,20.939025",
     "geom:latitude":20.265235,
     "geom:longitude":95.316115,
@@ -109,9 +109,10 @@
         "hasc:id":"MM.MG.MG",
         "wd:id":"Q6732567"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898361,
-    "wof:geomhash":"0c707eb3a41d304c8488ae0166ec2cb6",
+    "wof:geomhash":"912bef3bf313619b861f69cf40076b14",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1092046159,
-    "wof:lastmodified":1690939661,
+    "wof:lastmodified":1695886166,
     "wof:name":"Magway",
     "wof:parent_id":85674589,
     "wof:placetype":"county",

--- a/data/109/204/620/5/1092046205.geojson
+++ b/data/109/204/620/5/1092046205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080114,
-    "geom:area_square_m":918724253.208148,
+    "geom:area_square_m":918724253.208183,
     "geom:bbox":"95.984136,21.771705,96.361765,22.167299",
     "geom:latitude":21.963493,
     "geom:longitude":96.164179,
@@ -105,12 +105,13 @@
         "hasc:id":"MM.ML.MA",
         "wd:id":"Q3825102"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         890443763
     ],
     "wof:country":"MM",
     "wof:created":1473898363,
-    "wof:geomhash":"9207e5d5628444e9a6971de397e8f34c",
+    "wof:geomhash":"fd100ea927d53ea33561fa320cc9b5a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092046205,
-    "wof:lastmodified":1690939655,
+    "wof:lastmodified":1695886161,
     "wof:name":"Mandalay",
     "wof:parent_id":85674559,
     "wof:placetype":"county",

--- a/data/109/204/624/5/1092046245.geojson
+++ b/data/109/204/624/5/1092046245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.684817,
-    "geom:area_square_m":7836377352.622858,
+    "geom:area_square_m":7836377333.634034,
     "geom:bbox":"98.517254,21.484096,99.385624,22.891775",
     "geom:latitude":22.265348,
     "geom:longitude":98.896223,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"MM.SH.LS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898364,
-    "wof:geomhash":"575b733748588eec22ce7f04ee73acdc",
+    "wof:geomhash":"05e06af36c91e4265ac0b9f092692e0d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092046245,
-    "wof:lastmodified":1627522356,
+    "wof:lastmodified":1695886802,
     "wof:name":"Matman",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/628/9/1092046289.geojson
+++ b/data/109/204/628/9/1092046289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.372666,
-    "geom:area_square_m":4407928189.326342,
+    "geom:area_square_m":4407927846.740637,
     "geom:bbox":"95.20317,16.507677,95.885847,17.411984",
     "geom:latitude":16.947847,
     "geom:longitude":95.569612,
@@ -96,9 +96,10 @@
         "hasc:id":"MM.AY.MU",
         "wd:id":"Q6720647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898366,
-    "wof:geomhash":"f1a5d1a088730e5e272931434a9d6f8f",
+    "wof:geomhash":"84d54ad255b8d2440b87b4ebd07f8e04",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1092046289,
-    "wof:lastmodified":1690939654,
+    "wof:lastmodified":1695886802,
     "wof:name":"Maubin",
     "wof:parent_id":85674585,
     "wof:placetype":"county",

--- a/data/109/204/631/7/1092046317.geojson
+++ b/data/109/204/631/7/1092046317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319232,
-    "geom:area_square_m":3684421311.708239,
+    "geom:area_square_m":3684421089.453894,
     "geom:bbox":"92.171808,20.448535,92.749499,21.47971",
     "geom:latitude":21.029761,
     "geom:longitude":92.482533,
@@ -103,9 +103,10 @@
         "hasc:id":"MM.RA.MX",
         "wd:id":"Q6792575"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898367,
-    "wof:geomhash":"96bc720cd5556d304f61cc865baff34b",
+    "wof:geomhash":"e738969cf1cf694f9cb8809170062eaf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1092046317,
-    "wof:lastmodified":1690939663,
+    "wof:lastmodified":1695886802,
     "wof:name":"Maungdaw",
     "wof:parent_id":85674579,
     "wof:placetype":"county",

--- a/data/109/204/636/1/1092046361.geojson
+++ b/data/109/204/636/1/1092046361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.680473,
-    "geom:area_square_m":7688451739.697084,
+    "geom:area_square_m":7688451872.953252,
     "geom:bbox":"94.190714,23.313286,95.357928,24.582255",
     "geom:latitude":23.969527,
     "geom:longitude":94.74653,
@@ -88,9 +88,10 @@
         "hasc:id":"MM.SA.MW",
         "wd:id":"Q6794421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898368,
-    "wof:geomhash":"ce842f178a519640b97447e83b350b89",
+    "wof:geomhash":"94fce1647bdadf2e50348c4af9a1b858",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1092046361,
-    "wof:lastmodified":1690939663,
+    "wof:lastmodified":1695886802,
     "wof:name":"Mawlaik",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/640/7/1092046407.geojson
+++ b/data/109/204/640/7/1092046407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.51127,
-    "geom:area_square_m":6083222177.324924,
+    "geom:area_square_m":6083221975.700961,
     "geom:bbox":"97.445389,14.8799,98.231354,16.601928",
     "geom:latitude":15.788284,
     "geom:longitude":97.846364,
@@ -102,9 +102,10 @@
         "hasc:id":"MM.MO.ML",
         "wd:id":"Q6794425"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898370,
-    "wof:geomhash":"2d6e7c2fa8b8c4e332c2a7fdb1b3bdd0",
+    "wof:geomhash":"d0b88d8c68424d4d2e8306b2edd71716",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092046407,
-    "wof:lastmodified":1690939661,
+    "wof:lastmodified":1695886166,
     "wof:name":"Mawlamyine",
     "wof:parent_id":85674575,
     "wof:placetype":"county",

--- a/data/109/204/644/3/1092046443.geojson
+++ b/data/109/204/644/3/1092046443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.502168,
-    "geom:area_square_m":5798524749.593464,
+    "geom:area_square_m":5798524678.504692,
     "geom:bbox":"95.465795,20.507925,96.577376,21.409867",
     "geom:latitude":20.959266,
     "geom:longitude":95.973485,
@@ -97,9 +97,10 @@
         "hasc:id":"MM.ML.ME",
         "wd:id":"Q6810080"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898371,
-    "wof:geomhash":"34fb5bedd4fb2ef11990c45f75854fa6",
+    "wof:geomhash":"ca63062f90a8e36c93f1489d25e9d8be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1092046443,
-    "wof:lastmodified":1690939654,
+    "wof:lastmodified":1695886803,
     "wof:name":"Meiktila",
     "wof:parent_id":85674559,
     "wof:placetype":"county",

--- a/data/109/204/648/3/1092046483.geojson
+++ b/data/109/204/648/3/1092046483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.80544,
-    "geom:area_square_m":9335708342.397705,
+    "geom:area_square_m":9335708107.762005,
     "geom:bbox":"93.847579,19.710919,95.004662,20.982505",
     "geom:latitude":20.382652,
     "geom:longitude":94.457513,
@@ -96,9 +96,10 @@
         "hasc:id":"MM.MG.MB",
         "wd:id":"Q6863305"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898373,
-    "wof:geomhash":"ae760469874a863cf0bfbe7354a3fa58",
+    "wof:geomhash":"46a24c4d627d8d4218f313a8d4774c87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1092046483,
-    "wof:lastmodified":1690939662,
+    "wof:lastmodified":1695886803,
     "wof:name":"Minbu",
     "wof:parent_id":85674589,
     "wof:placetype":"county",

--- a/data/109/204/653/1/1092046531.geojson
+++ b/data/109/204/653/1/1092046531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.719172,
-    "geom:area_square_m":19780397972.999916,
+    "geom:area_square_m":19780397546.957371,
     "geom:bbox":"92.600934,20.641404,94.120247,22.227111",
     "geom:latitude":21.484555,
     "geom:longitude":93.398295,
@@ -93,9 +93,10 @@
         "hasc:id":"MM.CH.MI",
         "wd:id":"Q6863716"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898374,
-    "wof:geomhash":"609f072a26fa6a3d271b0b26dc4d4cb9",
+    "wof:geomhash":"4592339b756131febe614870df270b5c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1092046531,
-    "wof:lastmodified":1690939663,
+    "wof:lastmodified":1695886803,
     "wof:name":"Mindat",
     "wof:parent_id":85674581,
     "wof:placetype":"county",

--- a/data/109/204/657/9/1092046579.geojson
+++ b/data/109/204/657/9/1092046579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.381913,
-    "geom:area_square_m":15447965231.007257,
+    "geom:area_square_m":15447965826.052698,
     "geom:bbox":"95.814369,24.479844,97.200314,26.133939",
     "geom:latitude":25.302289,
     "geom:longitude":96.497911,
@@ -85,9 +85,10 @@
         "hasc:id":"MM.KC.MT",
         "wd:id":"Q6894270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898376,
-    "wof:geomhash":"000bd02910915b47ca395c093754b523",
+    "wof:geomhash":"89fa6d31be6c525a0a87e513574374c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1092046579,
-    "wof:lastmodified":1690939656,
+    "wof:lastmodified":1695886803,
     "wof:name":"Mohnyin",
     "wof:parent_id":85674605,
     "wof:placetype":"county",

--- a/data/109/204/662/3/1092046623.geojson
+++ b/data/109/204/662/3/1092046623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.577711,
-    "geom:area_square_m":6658954663.61256,
+    "geom:area_square_m":6658954376.053506,
     "geom:bbox":"99.455414,20.735371,101.170272,21.77776",
     "geom:latitude":21.223261,
     "geom:longitude":100.347154,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"MM.SH.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898378,
-    "wof:geomhash":"9eb592678b277798ab98529322f68e74",
+    "wof:geomhash":"c18d6b8278481f6eb0c1386ae21b93d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092046623,
-    "wof:lastmodified":1627522357,
+    "wof:lastmodified":1695886803,
     "wof:name":"Monghpyak",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/668/3/1092046683.geojson
+++ b/data/109/204/668/3/1092046683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.368567,
-    "geom:area_square_m":15832037279.364277,
+    "geom:area_square_m":15832037094.49044,
     "geom:bbox":"98.484859,19.718147,99.68133,21.656084",
     "geom:latitude":20.676555,
     "geom:longitude":99.011993,
@@ -89,9 +89,10 @@
         "hasc:id":"MM.SH.MH",
         "wd:id":"Q15255093"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898380,
-    "wof:geomhash":"ea88175f2452b990c6a1661f9d56f6ce",
+    "wof:geomhash":"9111c580005a1793cf7f3e7413267354",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092046683,
-    "wof:lastmodified":1690939656,
+    "wof:lastmodified":1695886803,
     "wof:name":"Monghsat",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/671/9/1092046719.geojson
+++ b/data/109/204/671/9/1092046719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.305686,
-    "geom:area_square_m":3498221978.137742,
+    "geom:area_square_m":3498222225.09205,
     "geom:bbox":"94.936243,21.791157,95.649167,22.632515",
     "geom:latitude":22.257342,
     "geom:longitude":95.264317,
@@ -93,9 +93,10 @@
         "hasc:id":"MM.SA.MO",
         "wd:id":"Q11013398"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898381,
-    "wof:geomhash":"b93eb56c14c94cc348461e5eabf20431",
+    "wof:geomhash":"9dfdb4e78affa1819bf5d65d573457cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1092046719,
-    "wof:lastmodified":1690939661,
+    "wof:lastmodified":1695886166,
     "wof:name":"Monywa",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/676/5/1092046765.geojson
+++ b/data/109/204/676/5/1092046765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.726511,
-    "geom:area_square_m":8415766431.079873,
+    "geom:area_square_m":8415765990.372975,
     "geom:bbox":"92.717528,19.647028,93.866716,21.211385",
     "geom:latitude":20.474829,
     "geom:longitude":93.356179,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"MM.RA.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898383,
-    "wof:geomhash":"8e5c65c0d79c6e884a05a47b87dbff79",
+    "wof:geomhash":"ced99c9d0b05f948b8b88b874164cfbd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1092046765,
-    "wof:lastmodified":1627522358,
+    "wof:lastmodified":1695886803,
     "wof:name":"Mrauk-U",
     "wof:parent_id":85674579,
     "wof:placetype":"county",

--- a/data/109/204/681/1/1092046811.geojson
+++ b/data/109/204/681/1/1092046811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.656061,
-    "geom:area_square_m":7428216254.112294,
+    "geom:area_square_m":7428216022.553525,
     "geom:bbox":"97.341832,23.296411,98.593335,24.131124",
     "geom:latitude":23.698032,
     "geom:longitude":98.019612,
@@ -91,9 +91,10 @@
         "hasc:id":"MM.SH.MS",
         "wd:id":"Q15260159"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898385,
-    "wof:geomhash":"5071ac12339e924344f5dab89939f552",
+    "wof:geomhash":"676d0aa361602ddb716d18dedd027a30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092046811,
-    "wof:lastmodified":1690939654,
+    "wof:lastmodified":1695886804,
     "wof:name":"Muse",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/685/7/1092046857.geojson
+++ b/data/109/204/685/7/1092046857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.262492,
-    "geom:area_square_m":3110391309.384337,
+    "geom:area_square_m":3110391547.517456,
     "geom:bbox":"94.684792,16.27527,95.480999,16.96705",
     "geom:latitude":16.605651,
     "geom:longitude":95.07155,
@@ -94,9 +94,10 @@
         "hasc:id":"MM.AY.MM",
         "wd:id":"Q6946820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898386,
-    "wof:geomhash":"902e1ab02fcc51a035bdd93cbbe8b360",
+    "wof:geomhash":"43989dfd0803ba0f324ad33d20ab41f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092046857,
-    "wof:lastmodified":1690939661,
+    "wof:lastmodified":1695886804,
     "wof:name":"Myaungmya",
     "wof:parent_id":85674585,
     "wof:placetype":"county",

--- a/data/109/204/690/1/1092046901.geojson
+++ b/data/109/204/690/1/1092046901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265462,
-    "geom:area_square_m":3146486556.260675,
+    "geom:area_square_m":3146487362.852489,
     "geom:bbox":"98.162841,16.039818,98.931778,17.089249",
     "geom:latitude":16.548571,
     "geom:longitude":98.520874,
@@ -94,9 +94,10 @@
         "hasc:id":"MM.KN.MY",
         "wd:id":"Q6946819"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898388,
-    "wof:geomhash":"22fc89d3855e31cc93035fa4439b28db",
+    "wof:geomhash":"5c3d60b7239d6bc590a33cce8777a0cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092046901,
-    "wof:lastmodified":1627522358,
+    "wof:lastmodified":1695886804,
     "wof:name":"Myawaddy",
     "wof:parent_id":85674557,
     "wof:placetype":"county",

--- a/data/109/204/695/1/1092046951.geojson
+++ b/data/109/204/695/1/1092046951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.241484,
-    "geom:area_square_m":14989679077.735212,
+    "geom:area_square_m":14989679491.511539,
     "geom:bbox":"98.234558,11.316073,99.664822,13.52223",
     "geom:latitude":12.447217,
     "geom:longitude":99.059747,
@@ -100,9 +100,10 @@
         "hasc:id":"MM.TN.MK",
         "wd:id":"Q6947286"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898389,
-    "wof:geomhash":"69d54cdc6459d7aac2ff41ea9737bf99",
+    "wof:geomhash":"5585faaed152edd8f3a97815adbefdca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1092046951,
-    "wof:lastmodified":1636504979,
+    "wof:lastmodified":1695886162,
     "wof:name":"Myeik",
     "wof:parent_id":85674599,
     "wof:placetype":"county",

--- a/data/109/204/699/9/1092046999.geojson
+++ b/data/109/204/699/9/1092046999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.565645,
-    "geom:area_square_m":6517158766.899927,
+    "geom:area_square_m":6517159132.910126,
     "geom:bbox":"94.992319,20.544574,95.980553,21.928803",
     "geom:latitude":21.283221,
     "geom:longitude":95.461253,
@@ -105,9 +105,10 @@
         "hasc:id":"MM.ML.MN",
         "wd:id":"Q13651432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898391,
-    "wof:geomhash":"6c1ba95014369338774259523ee64f43",
+    "wof:geomhash":"dcecac2cc8eb027f2cfbd62d4ca8581c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1092046999,
-    "wof:lastmodified":1690939662,
+    "wof:lastmodified":1695886167,
     "wof:name":"Myingyan",
     "wof:parent_id":85674559,
     "wof:placetype":"county",

--- a/data/109/204/703/7/1092047037.geojson
+++ b/data/109/204/703/7/1092047037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.155713,
-    "geom:area_square_m":35066556187.60379,
+    "geom:area_square_m":35066554905.205124,
     "geom:bbox":"95.996952,24.549872,98.782209,27.106833",
     "geom:latitude":26.011617,
     "geom:longitude":97.418485,
@@ -105,9 +105,10 @@
         "hasc:id":"MM.KC.MT",
         "wd:id":"Q11917400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898393,
-    "wof:geomhash":"e39188cdad0203f43db8805a411004fb",
+    "wof:geomhash":"68469449261f0da4fa710baf7670a0e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1092047037,
-    "wof:lastmodified":1690939659,
+    "wof:lastmodified":1695886165,
     "wof:name":"Myitkyina",
     "wof:parent_id":85674605,
     "wof:placetype":"county",

--- a/data/109/204/706/1/1092047061.geojson
+++ b/data/109/204/706/1/1092047061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127005,
-    "geom:area_square_m":1465291747.107945,
+    "geom:area_square_m":1465292046.760436,
     "geom:bbox":"94.828847,20.859534,95.230983,21.316327",
     "geom:latitude":21.085321,
     "geom:longitude":95.020606,
@@ -98,9 +98,10 @@
         "hasc:id":"MM.ML.NY",
         "wd:id":"Q959083"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898395,
-    "wof:geomhash":"8e9f2aa5b3953f4249cb8fe38ef207e0",
+    "wof:geomhash":"27a9e84eb792a57632b03eef8201ee9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092047061,
-    "wof:lastmodified":1690939652,
+    "wof:lastmodified":1695886804,
     "wof:name":"Nyaung-U",
     "wof:parent_id":85674559,
     "wof:placetype":"county",

--- a/data/109/204/706/3/1092047063.geojson
+++ b/data/109/204/706/3/1092047063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.306183,
-    "geom:area_square_m":3556594773.236063,
+    "geom:area_square_m":3556594384.776591,
     "geom:bbox":"95.739496,19.743893,96.504427,20.330936",
     "geom:latitude":20.047909,
     "geom:longitude":96.138321,
@@ -59,9 +59,10 @@
     "wof:concordances":{
         "hasc:id":"MM.MD.YM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898397,
-    "wof:geomhash":"886c982098ed2435ab139144138e9508",
+    "wof:geomhash":"43a6fa23c8f98549847177c7173380b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1092047063,
-    "wof:lastmodified":1627522359,
+    "wof:lastmodified":1695886804,
     "wof:name":"Oke Ta Ra",
     "wof:parent_id":1108804897,
     "wof:placetype":"county",

--- a/data/109/204/706/5/1092047065.geojson
+++ b/data/109/204/706/5/1092047065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.723439,
-    "geom:area_square_m":8326869723.87036,
+    "geom:area_square_m":8326869026.478202,
     "geom:bbox":"94.267574,20.840196,95.341706,21.871082",
     "geom:latitude":21.431174,
     "geom:longitude":94.730634,
@@ -132,9 +132,10 @@
         "hasc:id":"MM.MG.PK",
         "wd:id":"Q3826764"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898398,
-    "wof:geomhash":"e679ef875c8f8dcd299a0cf3ee4e1e00",
+    "wof:geomhash":"259ede52958d5fdd9ebbb430255ecf90",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1092047065,
-    "wof:lastmodified":1690939652,
+    "wof:lastmodified":1695886161,
     "wof:name":"Pakokku",
     "wof:parent_id":85674589,
     "wof:placetype":"county",

--- a/data/109/204/708/3/1092047083.geojson
+++ b/data/109/204/708/3/1092047083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.895128,
-    "geom:area_square_m":10592585734.199362,
+    "geom:area_square_m":10592586820.595163,
     "geom:bbox":"94.190414,15.829583,95.431987,17.569033",
     "geom:latitude":16.856456,
     "geom:longitude":94.739553,
@@ -100,9 +100,10 @@
         "hasc:id":"MM.AY.PT",
         "wd:id":"Q7144735"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898400,
-    "wof:geomhash":"b5847b24382d7397101030e4d3129786",
+    "wof:geomhash":"a8af78ff8c6d72f3f6c55e8112cf85aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1092047083,
-    "wof:lastmodified":1690939652,
+    "wof:lastmodified":1695886804,
     "wof:name":"Pathein",
     "wof:parent_id":85674585,
     "wof:placetype":"county",

--- a/data/109/204/712/3/1092047123.geojson
+++ b/data/109/204/712/3/1092047123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.519611,
-    "geom:area_square_m":27690283348.458027,
+    "geom:area_square_m":27690284275.934837,
     "geom:bbox":"96.898355,25.967749,98.767608,28.547835",
     "geom:latitude":27.274923,
     "geom:longitude":97.784736,
@@ -90,9 +90,10 @@
         "hasc:id":"MM.KC.PU",
         "wd:id":"Q7262178"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898401,
-    "wof:geomhash":"b01e3c431c40245bf5392ebe67c5e060",
+    "wof:geomhash":"65a35f431b2290a037f9230b95c74a85",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1092047123,
-    "wof:lastmodified":1627522360,
+    "wof:lastmodified":1695886805,
     "wof:name":"Puta-O",
     "wof:parent_id":85674605,
     "wof:placetype":"county",

--- a/data/109/204/716/7/1092047167.geojson
+++ b/data/109/204/716/7/1092047167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.429302,
-    "geom:area_square_m":5098463969.061194,
+    "geom:area_square_m":5098463449.589849,
     "geom:bbox":"95.090385,15.707889,96.079559,16.633263",
     "geom:latitude":16.166169,
     "geom:longitude":95.535355,
@@ -91,9 +91,10 @@
         "hasc:id":"MM.AY.PP",
         "wd:id":"Q7262856"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898403,
-    "wof:geomhash":"abe05100b145e09c4c5dd6816f672b28",
+    "wof:geomhash":"08cf65539d714a1a8b86ba65808d1ebb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092047167,
-    "wof:lastmodified":1690939665,
+    "wof:lastmodified":1695886805,
     "wof:name":"Pyapon",
     "wof:parent_id":85674585,
     "wof:placetype":"county",

--- a/data/109/204/721/3/1092047213.geojson
+++ b/data/109/204/721/3/1092047213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.652793,
-    "geom:area_square_m":7642998619.955599,
+    "geom:area_square_m":7642999627.286325,
     "geom:bbox":"94.687132,18.357675,95.863159,19.191073",
     "geom:latitude":18.760834,
     "geom:longitude":95.301802,
@@ -120,9 +120,10 @@
         "hasc:id":"MM.BA.PY",
         "wd:id":"Q7262887"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898404,
-    "wof:geomhash":"a7277ad58b5aad5b2753bec46fdb37ec",
+    "wof:geomhash":"595f4c8302cccb98c28d3f1cbf09b1a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1092047213,
-    "wof:lastmodified":1690939664,
+    "wof:lastmodified":1695886167,
     "wof:name":"Pyay",
     "wof:parent_id":85674565,
     "wof:placetype":"county",

--- a/data/109/204/725/9/1092047259.geojson
+++ b/data/109/204/725/9/1092047259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.73353,
-    "geom:area_square_m":8371678947.755641,
+    "geom:area_square_m":8371678864.201945,
     "geom:bbox":"95.900028,21.66883,96.763457,23.682283",
     "geom:latitude":22.628094,
     "geom:longitude":96.25031,
@@ -88,9 +88,10 @@
         "hasc:id":"MM.ML.PL",
         "wd:id":"Q7263053"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898406,
-    "wof:geomhash":"d14e3bf01e653e107233a13238356d76",
+    "wof:geomhash":"f39ecf6ff8db44bee526fb20b3f0083b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1092047259,
-    "wof:lastmodified":1690939656,
+    "wof:lastmodified":1695886805,
     "wof:name":"Pyinoolwin",
     "wof:parent_id":85674559,
     "wof:placetype":"county",

--- a/data/109/204/729/5/1092047295.geojson
+++ b/data/109/204/729/5/1092047295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214358,
-    "geom:area_square_m":2457777282.880638,
+    "geom:area_square_m":2457777053.13628,
     "geom:bbox":"95.177674,21.578638,96.024242,22.250667",
     "geom:latitude":21.987577,
     "geom:longitude":95.644428,
@@ -114,9 +114,10 @@
         "hasc:id":"MM.SA.SA",
         "wd:id":"Q7398942"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898408,
-    "wof:geomhash":"808448942b805f350a0cf1ef78d3643c",
+    "wof:geomhash":"30c984b7c49b0d3abe2331261fcfd1c5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1092047295,
-    "wof:lastmodified":1690939666,
+    "wof:lastmodified":1695886167,
     "wof:name":"Sagaing",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/733/1/1092047331.geojson
+++ b/data/109/204/733/1/1092047331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.308671,
-    "geom:area_square_m":14893902733.856239,
+    "geom:area_square_m":14893902536.604376,
     "geom:bbox":"94.771681,22.176311,96.010956,23.863354",
     "geom:latitude":23.012291,
     "geom:longitude":95.448087,
@@ -124,9 +124,10 @@
         "hasc:id":"MM.SA.SH",
         "wd:id":"Q7505842"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898409,
-    "wof:geomhash":"a9736142fef91f2e47f9399e492aa093",
+    "wof:geomhash":"cf7c48ec73f3229d67ffbb0b20997218",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1092047331,
-    "wof:lastmodified":1636504980,
+    "wof:lastmodified":1695886165,
     "wof:name":"Shwebo",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/737/5/1092047375.geojson
+++ b/data/109/204/737/5/1092047375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.274146,
-    "geom:area_square_m":3177236928.395621,
+    "geom:area_square_m":3177236463.378932,
     "geom:bbox":"92.59962,19.787889,93.25042,21.015191",
     "geom:latitude":20.400182,
     "geom:longitude":92.907048,
@@ -102,9 +102,10 @@
         "hasc:id":"MM.RA.SI",
         "wd:id":"Q11917411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898411,
-    "wof:geomhash":"2edde4cd3aee860a3f39ba8e638ed691",
+    "wof:geomhash":"10b2c6eabb8cc86297766f183d33527c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092047375,
-    "wof:lastmodified":1690939653,
+    "wof:lastmodified":1695886162,
     "wof:name":"Sittwe",
     "wof:parent_id":85674579,
     "wof:placetype":"county",

--- a/data/109/204/739/7/1092047397.geojson
+++ b/data/109/204/739/7/1092047397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.34107,
-    "geom:area_square_m":3945224052.963682,
+    "geom:area_square_m":3945224116.990748,
     "geom:bbox":"99.441859,20.31624,100.649297,21.047316",
     "geom:latitude":20.696107,
     "geom:longitude":99.994299,
@@ -94,9 +94,10 @@
         "hasc:id":"MM.SH.TC",
         "wd:id":"Q7673734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898412,
-    "wof:geomhash":"fe7f4eee32c4fb05b3d04ec8c431c429",
+    "wof:geomhash":"2774e99d31251a02dd7884df9a17c89e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092047397,
-    "wof:lastmodified":1690939652,
+    "wof:lastmodified":1695886805,
     "wof:name":"Tachileik",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/744/7/1092047447.geojson
+++ b/data/109/204/744/7/1092047447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174403,
-    "geom:area_square_m":1967304782.528761,
+    "geom:area_square_m":1967304824.471221,
     "geom:bbox":"94.127894,23.645468,94.640098,24.73164",
     "geom:latitude":24.179532,
     "geom:longitude":94.387604,
@@ -90,9 +90,10 @@
         "hasc:id":"MM.SA.TM",
         "wd:id":"Q7681885"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898414,
-    "wof:geomhash":"f2351383c81fadd6f694f4ec3174b174",
+    "wof:geomhash":"76b1cccb2016642b3fda7b7545b95429",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1092047447,
-    "wof:lastmodified":1690939664,
+    "wof:lastmodified":1695886805,
     "wof:name":"Tamu",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/109/204/748/7/1092047487.geojson
+++ b/data/109/204/748/7/1092047487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.093857,
-    "geom:area_square_m":24205754460.55938,
+    "geom:area_square_m":24205754752.716866,
     "geom:bbox":"96.20779,19.306594,97.473403,22.269783",
     "geom:latitude":20.776029,
     "geom:longitude":96.906387,
@@ -107,9 +107,10 @@
         "hasc:id":"MM.SH.TG",
         "wd:id":"Q7688742"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898415,
-    "wof:geomhash":"cd1c7b35c66cda7e0ce0fef027a766f1",
+    "wof:geomhash":"2f306e26950350bc32e5a1835c37bb2f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1092047487,
-    "wof:lastmodified":1690939658,
+    "wof:lastmodified":1695886163,
     "wof:name":"Taunggyi",
     "wof:parent_id":85674595,
     "wof:placetype":"county",

--- a/data/109/204/752/3/1092047523.geojson
+++ b/data/109/204/752/3/1092047523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.912903,
-    "geom:area_square_m":10685011690.840172,
+    "geom:area_square_m":10685012434.072151,
     "geom:bbox":"95.79929,18.127984,97.139353,19.492925",
     "geom:latitude":18.812197,
     "geom:longitude":96.347248,
@@ -108,9 +108,10 @@
         "hasc:id":"MM.BA.TA",
         "wd:id":"Q7688753"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898417,
-    "wof:geomhash":"25e59953394ba6b796074e1228007953",
+    "wof:geomhash":"aed31028585f916477a5912c4a4a46a1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1092047523,
-    "wof:lastmodified":1636504978,
+    "wof:lastmodified":1695886162,
     "wof:name":"Taungoo",
     "wof:parent_id":85674565,
     "wof:placetype":"county",

--- a/data/109/204/756/9/1092047569.geojson
+++ b/data/109/204/756/9/1092047569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.898679,
-    "geom:area_square_m":10535685901.073311,
+    "geom:area_square_m":10535684994.180456,
     "geom:bbox":"94.024559,17.337262,94.899796,19.54",
     "geom:latitude":18.531654,
     "geom:longitude":94.501257,
@@ -96,9 +96,10 @@
         "hasc:id":"MM.RA.TD",
         "wd:id":"Q3826754"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898418,
-    "wof:geomhash":"27e206e68b3ec146f6e2d47e663d1b4d",
+    "wof:geomhash":"e454fa75f593687b05f17c958101aac5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1092047569,
-    "wof:lastmodified":1690939659,
+    "wof:lastmodified":1695886805,
     "wof:name":"Thandwe",
     "wof:parent_id":85674579,
     "wof:placetype":"county",

--- a/data/109/204/761/9/1092047619.geojson
+++ b/data/109/204/761/9/1092047619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.409218,
-    "geom:area_square_m":4835315044.494717,
+    "geom:area_square_m":4835314755.346167,
     "geom:bbox":"96.866742,16.501194,97.633999,17.713224",
     "geom:latitude":17.138066,
     "geom:longitude":97.27942,
@@ -93,9 +93,10 @@
         "hasc:id":"MM.MO.TT",
         "wd:id":"Q11917410"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898420,
-    "wof:geomhash":"c7026d34b55250f5501f8cd6ef855e83",
+    "wof:geomhash":"4fc707a301d86f9fa90a0a25983ebd97",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1092047619,
-    "wof:lastmodified":1690939660,
+    "wof:lastmodified":1695886805,
     "wof:name":"Thaton",
     "wof:parent_id":85674575,
     "wof:placetype":"county",

--- a/data/109/204/766/5/1092047665.geojson
+++ b/data/109/204/766/5/1092047665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.621139,
-    "geom:area_square_m":7300347627.199968,
+    "geom:area_square_m":7300347508.881645,
     "geom:bbox":"95.258284,17.466939,96.201992,18.794011",
     "geom:latitude":18.100099,
     "geom:longitude":95.751579,
@@ -94,9 +94,10 @@
         "hasc:id":"MM.BA.TW",
         "wd:id":"Q7710822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898421,
-    "wof:geomhash":"4c5bcab131e1dc5bd1ccaf0ffc2f7d49",
+    "wof:geomhash":"6674fca1ea6f8082779520a11d1ca5bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1092047665,
-    "wof:lastmodified":1690939660,
+    "wof:lastmodified":1695886008,
     "wof:name":"Thayarwady",
     "wof:parent_id":85674565,
     "wof:placetype":"county",

--- a/data/109/204/771/3/1092047713.geojson
+++ b/data/109/204/771/3/1092047713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.031617,
-    "geom:area_square_m":12029033401.166702,
+    "geom:area_square_m":12029033241.655293,
     "geom:bbox":"94.317548,18.835211,95.859612,20.000136",
     "geom:latitude":19.437126,
     "geom:longitude":95.051923,
@@ -91,9 +91,10 @@
         "hasc:id":"MM.MG.TY",
         "wd:id":"Q7711561"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898423,
-    "wof:geomhash":"cdd9393dd2ad5748b9d3d231515d67e1",
+    "wof:geomhash":"41f50ea4b4ffc48a84f496c012e11774",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1092047713,
-    "wof:lastmodified":1690939657,
+    "wof:lastmodified":1695886008,
     "wof:name":"Thayet",
     "wof:parent_id":85674589,
     "wof:placetype":"county",

--- a/data/109/204/776/3/1092047763.geojson
+++ b/data/109/204/776/3/1092047763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.328404,
-    "geom:area_square_m":3803802753.750889,
+    "geom:area_square_m":3803802286.889975,
     "geom:bbox":"95.568573,20.194937,96.544702,20.77572",
     "geom:latitude":20.492026,
     "geom:longitude":96.063177,
@@ -93,9 +93,10 @@
         "hasc:id":"MM.ML.YM",
         "wd:id":"Q8048034"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898424,
-    "wof:geomhash":"3cc492b23d280f92863eee4f8cab6623",
+    "wof:geomhash":"06e8bd570fabcdc3eb268e4068cdc7d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1092047763,
-    "wof:lastmodified":1690939657,
+    "wof:lastmodified":1695886008,
     "wof:name":"Yamethin",
     "wof:parent_id":85674559,
     "wof:placetype":"county",

--- a/data/109/204/780/9/1092047809.geojson
+++ b/data/109/204/780/9/1092047809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031335,
-    "geom:area_square_m":370733970.78475,
+    "geom:area_square_m":370733915.114934,
     "geom:bbox":"96.143438,16.76375,96.368201,17.023026",
     "geom:latitude":16.896129,
     "geom:longitude":96.248681,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"MM.YA.YE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898426,
-    "wof:geomhash":"02e13105a0f5a2cac3fa7ab0850eb1fb",
+    "wof:geomhash":"2c29a80f1210991afd3e69c4bd2f3cf7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092047809,
-    "wof:lastmodified":1627522362,
+    "wof:lastmodified":1695886008,
     "wof:name":"Yangon (East)",
     "wof:parent_id":85674569,
     "wof:placetype":"county",

--- a/data/109/204/783/5/1092047835.geojson
+++ b/data/109/204/783/5/1092047835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.39431,
-    "geom:area_square_m":4655899913.954018,
+    "geom:area_square_m":4655899725.571488,
     "geom:bbox":"95.618777,16.824899,96.404866,17.791967",
     "geom:latitude":17.269198,
     "geom:longitude":96.030574,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"MM.YA.YN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898427,
-    "wof:geomhash":"20e2e6b639df3b3f851c0cd9c480af03",
+    "wof:geomhash":"b8e09a8f91b26b228a7262ca6d353a2a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092047835,
-    "wof:lastmodified":1627522362,
+    "wof:lastmodified":1695886008,
     "wof:name":"Yangon (North)",
     "wof:parent_id":85674569,
     "wof:placetype":"county",

--- a/data/109/204/787/9/1092047879.geojson
+++ b/data/109/204/787/9/1092047879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.398503,
-    "geom:area_square_m":4720645907.736637,
+    "geom:area_square_m":4720645960.553173,
     "geom:bbox":"93.230392,13.969584,96.802179,16.998923",
     "geom:latitude":16.661029,
     "geom:longitude":96.27096,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"MM.YA.YS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898429,
-    "wof:geomhash":"30cd5011f5da5443c373697cd05243de",
+    "wof:geomhash":"79dbde6f06b7e6b0e88d9a728f72160a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092047879,
-    "wof:lastmodified":1627522362,
+    "wof:lastmodified":1695886008,
     "wof:name":"Yangon (South)",
     "wof:parent_id":85674569,
     "wof:placetype":"county",

--- a/data/109/204/792/3/1092047923.geojson
+++ b/data/109/204/792/3/1092047923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005995,
-    "geom:area_square_m":70947933.923603,
+    "geom:area_square_m":70947838.37105,
     "geom:bbox":"96.098775,16.766462,96.17413,16.904838",
     "geom:latitude":16.832915,
     "geom:longitude":96.138177,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"MM.YA.YW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898430,
-    "wof:geomhash":"d3fa60e54fee284f09652f9cc46a9175",
+    "wof:geomhash":"5ff67b3b5b4fb0c93f468e7b08131d80",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092047923,
-    "wof:lastmodified":1627522362,
+    "wof:lastmodified":1695886009,
     "wof:name":"Yangon (West)",
     "wof:parent_id":85674569,
     "wof:placetype":"county",

--- a/data/109/204/796/1/1092047961.geojson
+++ b/data/109/204/796/1/1092047961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.576501,
-    "geom:area_square_m":6597758396.769076,
+    "geom:area_square_m":6597758209.023662,
     "geom:bbox":"94.246725,21.784768,95.161834,22.832414",
     "geom:latitude":22.2488,
     "geom:longitude":94.715571,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"MM.SA.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"MM",
     "wof:created":1473898431,
-    "wof:geomhash":"05a1719851388c1c9e598e2816f492af",
+    "wof:geomhash":"8da5e12ab64c51051ec2da4681565ecf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1092047961,
-    "wof:lastmodified":1627522362,
+    "wof:lastmodified":1695886009,
     "wof:name":"Yinmabin",
     "wof:parent_id":85674607,
     "wof:placetype":"county",

--- a/data/110/880/489/7/1108804897.geojson
+++ b/data/110/880/489/7/1108804897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.609547,
-    "geom:area_square_m":7089504130.096615,
+    "geom:area_square_m":7089504003.975142,
     "geom:bbox":"95.711838,19.418204,96.673356,20.330936",
     "geom:latitude":19.844967,
     "geom:longitude":96.153635,
@@ -122,12 +122,14 @@
     "wof:concordances":{
         "fips:code":"BM18",
         "hasc:id":"MM.NY",
+        "iso:code":"MM-18",
         "iso:id":"MM-18",
         "wd:id":"Q4796"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:created":1485470526,
-    "wof:geomhash":"80fe5ab3f66d16be6c71d986c75512a9",
+    "wof:geomhash":"72c0616ade1792ce9db4b57da84a829f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -142,7 +144,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939649,
+    "wof:lastmodified":1695884325,
     "wof:name":"Naypyitaw",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/321/81/85632181.geojson
+++ b/data/856/321/81/85632181.geojson
@@ -1339,6 +1339,7 @@
         "hasc:id":"MM",
         "icao:code":"XY",
         "ioc:id":"MYA",
+        "iso:code":"MM",
         "itu:id":"MYA",
         "m49:code":"104",
         "marc:id":"br",
@@ -1352,6 +1353,7 @@
         "wk:page":"Myanmar",
         "wmo:id":"BM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:country_alpha3":"MMR",
     "wof:geom_alt":[
@@ -1373,7 +1375,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1694639568,
+    "wof:lastmodified":1695881227,
     "wof:name":"Myanmar",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/745/51/85674551.geojson
+++ b/data/856/745/51/85674551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.00973,
-    "geom:area_square_m":11788343709.424423,
+    "geom:area_square_m":11788343979.999567,
     "geom:bbox":"96.819841,18.491094,97.888151,19.996601",
     "geom:latitude":19.234331,
     "geom:longitude":97.374753,
@@ -171,15 +171,17 @@
         "gn:id":1319539,
         "gp:id":2344815,
         "hasc:id":"MM.KH",
+        "iso:code":"MM-12",
         "iso:id":"MM-12",
         "qs_pg:id":239500,
         "unlc:id":"MM-12"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe319144ff10bc97537b94d759c7c6ca",
+    "wof:geomhash":"967d9826a916e7e6b36addb6292edade",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -194,7 +196,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1636504963,
+    "wof:lastmodified":1695884960,
     "wof:name":"Kayah",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/57/85674557.geojson
+++ b/data/856/745/57/85674557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.575553,
-    "geom:area_square_m":30425414155.345978,
+    "geom:area_square_m":30425413767.528473,
     "geom:bbox":"96.394527,15.220098,98.931777,19.505371",
     "geom:latitude":17.151535,
     "geom:longitude":97.786922,
@@ -329,17 +329,19 @@
         "gn:id":1320233,
         "gp:id":2344814,
         "hasc:id":"MM.KN",
+        "iso:code":"MM-13",
         "iso:id":"MM-13",
         "qs_pg:id":235564,
         "unlc:id":"MM-13",
         "wd:id":"Q495342",
         "wk:page":"Kayin State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b53addbc7d544d2f5fb856d97f181fd",
+    "wof:geomhash":"76d31c8c81e7153b8244b6b5b5065313",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -354,7 +356,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939637,
+    "wof:lastmodified":1695884959,
     "wof:name":"Kayin",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/59/85674559.geojson
+++ b/data/856/745/59/85674559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.699185,
-    "geom:area_square_m":31040244768.227646,
+    "geom:area_square_m":31040245209.357033,
     "geom:bbox":"94.828847,20.194937,96.893695,23.682283",
     "geom:latitude":21.547719,
     "geom:longitude":95.947138,
@@ -335,17 +335,19 @@
         "gn:id":1311871,
         "gp:id":2344817,
         "hasc:id":"MM.ML",
+        "iso:code":"MM-04",
         "iso:id":"MM-04",
         "qs_pg:id":901859,
         "unlc:id":"MM-04",
         "wd:id":"Q119494",
         "wk:page":"Mandalay Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"697198e14c6da4f4ec3873bb0d6e157d",
+    "wof:geomhash":"e3f73ae0140c8da44b1de825a9034bca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -360,7 +362,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939637,
+    "wof:lastmodified":1695884960,
     "wof:name":"Mandalay",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/65/85674565.geojson
+++ b/data/856/745/65/85674565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.314804,
-    "geom:area_square_m":38913380358.655296,
+    "geom:area_square_m":38913383057.979836,
     "geom:bbox":"94.687132,16.817888,97.222453,19.492925",
     "geom:latitude":18.299358,
     "geom:longitude":96.113901,
@@ -322,17 +322,19 @@
         "gn:id":1300463,
         "gp:id":2344818,
         "hasc:id":"MM.BA",
+        "iso:code":"MM-02",
         "iso:id":"MM-02",
         "qs_pg:id":235565,
         "unlc:id":"MM-02",
         "wd:id":"Q800124",
         "wk:page":"Bago Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9bd00c806b6f98299982a17d01021310",
+    "wof:geomhash":"aec56d8aba9f8b8c3eb92f8431da3a60",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939639,
+    "wof:lastmodified":1695884960,
     "wof:name":"Bago",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/69/85674569.geojson
+++ b/data/856/745/69/85674569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.830276,
-    "geom:area_square_m":9819804896.031736,
+    "geom:area_square_m":9819804638.332859,
     "geom:bbox":"93.230392,13.969584,96.802179,17.791967",
     "geom:latitude":16.960018,
     "geom:longitude":96.154935,
@@ -342,17 +342,19 @@
         "gn:id":1298822,
         "gp:id":2344823,
         "hasc:id":"MM.YA",
+        "iso:code":"MM-06",
         "iso:id":"MM-06",
         "qs_pg:id":219514,
         "unlc:id":"MM-06",
         "wd:id":"Q856781",
         "wk:page":"Yangon Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"82e8cce1ebbf365e3a1db8f042012949",
+    "wof:geomhash":"8c857a330f942deceddaea07d7d05821",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -367,7 +369,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939638,
+    "wof:lastmodified":1695884960,
     "wof:name":"Yangon",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/75/85674575.geojson
+++ b/data/856/745/75/85674575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.920488,
-    "geom:area_square_m":10918537221.819695,
+    "geom:area_square_m":10918536731.047215,
     "geom:bbox":"96.866742,14.8799,98.231354,17.713224",
     "geom:latitude":16.388352,
     "geom:longitude":97.59432,
@@ -317,17 +317,19 @@
         "gn:id":1308528,
         "gp:id":2344822,
         "hasc:id":"MM.MO",
+        "iso:code":"MM-15",
         "iso:id":"MM-15",
         "qs_pg:id":235566,
         "unlc:id":"MM-15",
         "wd:id":"Q818742",
         "wk:page":"Mon State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b8e73aeea9f48fab5e0893442417f688",
+    "wof:geomhash":"66622d84241b544b36c9b2d98c82a06f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -342,7 +344,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939638,
+    "wof:lastmodified":1695884960,
     "wof:name":"Mon",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/79/85674579.geojson
+++ b/data/856/745/79/85674579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.994484,
-    "geom:area_square_m":34846843538.133957,
+    "geom:area_square_m":34846841987.314804,
     "geom:bbox":"92.171808,17.337262,94.899796,21.47971",
     "geom:latitude":19.737594,
     "geom:longitude":93.713279,
@@ -333,17 +333,19 @@
         "gn:id":1298852,
         "gp:id":2344810,
         "hasc:id":"MM.RA",
+        "iso:code":"MM-16",
         "iso:id":"MM-16",
         "qs_pg:id":219511,
         "unlc:id":"MM-16",
         "wd:id":"Q233838",
         "wk:page":"Rakhine State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"75ab170da6f3c38a5f02d5a3eb3b55f3",
+    "wof:geomhash":"1c45e3e58b3be6e2bab95ed2b19be8e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -358,7 +360,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939641,
+    "wof:lastmodified":1695884962,
     "wof:name":"Rakhine",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/81/85674581.geojson
+++ b/data/856/745/81/85674581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.153062,
-    "geom:area_square_m":36101572203.893524,
+    "geom:area_square_m":36101572414.716339,
     "geom:bbox":"92.600934,20.641404,94.151813,24.106396",
     "geom:latitude":22.169771,
     "geom:longitude":93.509674,
@@ -332,17 +332,19 @@
         "gn:id":1327132,
         "gp:id":2344811,
         "hasc:id":"MM.CH",
+        "iso:code":"MM-14",
         "iso:id":"MM-14",
         "qs_pg:id":229363,
         "unlc:id":"MM-14",
         "wd:id":"Q46910",
         "wk:page":"Chin State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05fa77e6f40a3a8c5ef1580d16e2effa",
+    "wof:geomhash":"b770538520babf20397feb36c6c2f4b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -357,7 +359,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939639,
+    "wof:lastmodified":1695884961,
     "wof:name":"Chin",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/85/85674585.geojson
+++ b/data/856/745/85/85674585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.898422,
-    "geom:area_square_m":34294826118.46236,
+    "geom:area_square_m":34294825716.527328,
     "geom:bbox":"94.190414,15.707889,96.079559,18.510625",
     "geom:latitude":16.870585,
     "geom:longitude":95.115773,
@@ -349,16 +349,18 @@
         "gn:id":1321850,
         "gp:id":2344812,
         "hasc:id":"MM.AY",
+        "iso:code":"MM-07",
         "iso:id":"MM-07",
         "qs_pg:id":219512,
         "wd:id":"Q47047",
         "wk:page":"Ayeyarwady Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"61e3a7fedb35cf72dae8a51a449c1c4f",
+    "wof:geomhash":"fd7a87a09e8c52c53996522b1dcdc58b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -373,7 +375,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939641,
+    "wof:lastmodified":1695884962,
     "wof:name":"Ayeyarwady",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/89/85674589.geojson
+++ b/data/856/745/89/85674589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.882804,
-    "geom:area_square_m":44971620583.43325,
+    "geom:area_square_m":44971619817.929237,
     "geom:bbox":"93.847579,18.835211,95.859612,22.763971",
     "geom:latitude":20.480113,
     "geom:longitude":94.816186,
@@ -315,17 +315,19 @@
         "gn:id":1312604,
         "gp:id":2344816,
         "hasc:id":"MM.MG",
+        "iso:code":"MM-03",
         "iso:id":"MM-03",
         "qs_pg:id":901861,
         "unlc:id":"MM-03",
         "wd:id":"Q833013",
         "wk:page":"Magway Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b303d8bb30f06358f30bebfab2c084f6",
+    "wof:geomhash":"3cc9695eb2a1940e26175c4aad148cf9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -340,7 +342,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939638,
+    "wof:lastmodified":1695884960,
     "wof:name":"Magway",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/95/85674595.geojson
+++ b/data/856/745/95/85674595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.591264,
-    "geom:area_square_m":156092332510.069977,
+    "geom:area_square_m":156092332567.62326,
     "geom:bbox":"96.150842,19.306594,101.170272,24.161715",
     "geom:latitude":21.722872,
     "geom:longitude":98.122079,
@@ -327,17 +327,19 @@
         "gn:id":1297099,
         "gp:id":2344820,
         "hasc:id":"MM.SH",
+        "iso:code":"MM-17",
         "iso:id":"MM-17",
         "qs_pg:id":894849,
         "unlc:id":"MM-17",
         "wd:id":"Q456847",
         "wk:page":"Shan State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee8275d43ceeb232de3c3f0c32b4fc36",
+    "wof:geomhash":"b816bc675063c8698781776d83f9cdaa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -352,7 +354,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939636,
+    "wof:lastmodified":1695884958,
     "wof:name":"Shan",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/745/99/85674599.geojson
+++ b/data/856/745/99/85674599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.396034,
-    "geom:area_square_m":40959911308.62574,
+    "geom:area_square_m":40959911694.529732,
     "geom:bbox":"97.442108,9.59875,99.664822,15.10223",
     "geom:latitude":12.673917,
     "geom:longitude":98.749886,
@@ -321,15 +321,17 @@
         "gn:id":1293118,
         "gp:id":2344821,
         "hasc:id":"MM.TN",
+        "iso:code":"MM-05",
         "iso:id":"MM-05",
         "qs_pg:id":239499,
         "wd:id":"Q843954"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"169f6fdcd1b78954864118ae4346a658",
+    "wof:geomhash":"bf4381c445e943d36261f0b954887fa4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -344,7 +346,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939640,
+    "wof:lastmodified":1695884961,
     "wof:name":"Tanintharyi",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/746/05/85674605.geojson
+++ b/data/856/746/05/85674605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.019351,
-    "geom:area_square_m":89050954397.192947,
+    "geom:area_square_m":89050953826.202759,
     "geom:bbox":"95.814369,23.634138,98.782209,28.547835",
     "geom:latitude":26.075926,
     "geom:longitude":97.344157,
@@ -338,17 +338,19 @@
         "gn:id":1321702,
         "gp:id":2344813,
         "hasc:id":"MM.KC",
+        "iso:code":"MM-11",
         "iso:id":"MM-11",
         "qs_pg:id":219513,
         "unlc:id":"MM-11",
         "wd:id":"Q140646",
         "wk:page":"Kachin State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"440067f085f8feca3b30f9a7fa390020",
+    "wof:geomhash":"4fe8317fa2265a915d4d41f8e73d2d7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939631,
+    "wof:lastmodified":1695884958,
     "wof:name":"Kachin",
     "wof:parent_id":85632181,
     "wof:placetype":"region",

--- a/data/856/746/07/85674607.geojson
+++ b/data/856/746/07/85674607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.315191,
-    "geom:area_square_m":93778459429.731049,
+    "geom:area_square_m":93778459843.882172,
     "geom:bbox":"93.948932,21.578638,97.069332,27.376638",
     "geom:latitude":24.167274,
     "geom:longitude":95.324061,
@@ -309,16 +309,18 @@
         "gn:id":1298480,
         "gp:id":2344819,
         "hasc:id":"MM.SA",
+        "iso:code":"MM-01",
         "iso:id":"MM-01",
         "qs_pg:id":900663,
         "unlc:id":"MM-01",
         "wd:id":"Q847289"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c0a9ca362c1c99d3c327fdce38bc86b3",
+    "wof:geomhash":"c615661501520105f193c305fc5678d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "mya"
     ],
-    "wof:lastmodified":1690939631,
+    "wof:lastmodified":1695884959,
     "wof:name":"Sagaing",
     "wof:parent_id":85632181,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.